### PR TITLE
Don't sleep while updating display, tested version

### DIFF
--- a/HB-Dis-EP-42BW.ino
+++ b/HB-Dis-EP-42BW.ino
@@ -244,6 +244,7 @@ public:
 
   void isWaiting(bool w) {
     waiting = w;
+    DPRINT("wait:"); DDECLN(waiting);
   }
 
   bool isWaiting() {
@@ -686,10 +687,11 @@ void loop() {
     if (hal.battery.critical()) {
       hal.activity.sleepForever(hal);
     }
-    //if (ePaper.isWaiting() == false)
+    if (ePaper.isWaiting()) {
+      hal.activity.savePower<Idle<>>(hal);
+    } else {
       hal.activity.savePower<Sleep<>>(hal);
-    //else
-    //  hal.activity.savePower<Idle<>>(hal);
+    }
 #else
     hal.activity.savePower<Idle<>>(hal);
 #endif


### PR DESCRIPTION
Hi Jerome,
anbei der von mir etwas länger getestete Stand zur aktuellen Waiting/Sleep Arbeit.
Ich schlage nur 2 kleine Änderungen gegenüber dem aktuellen Stand vor:
- die Debugausgabe für isWaiting() erst mal drinlassen falls es noch irgendwo Probleme mit dem Sleep geben sollte, so sieht man auf einen Blick den isWaiting Status
- in der loop() würde ich if (ePaper.isWaiting()) auf true testen und dann Idle oben schreiben, ist etwas schöner zu lesen statt die inverse Logik mit Test auf false.

Ich habe auch die Stromaufnahme rudimentär angeschaut (nur Multimeter) das ePaper geht bei mir immer wieder in den Sleep wie es soll.
